### PR TITLE
Tuple input

### DIFF
--- a/src/DiffDynProg.jl
+++ b/src/DiffDynProg.jl
@@ -1,6 +1,7 @@
 module DiffDynProg
 
-export MaxOperator, Max, LeakyMax, EntropyMax, SquaredMax, max_argmax, min_argmin
+export MaxOperator, Max, LeakyMax, EntropyMax, SquaredMax, smoothmax, smoothmin, smoothmax_argmax, smoothmin_argmin
+export maxᵧ, minᵧ, max_argmaxᵧ, min_argminᵧ
 export gap_cost_matrix, gumbel_softmax
 export DP, getD, getE, getQ
 export dynamic_time_warping, ∂DTW

--- a/src/dynamictimewarping.jl
+++ b/src/dynamictimewarping.jl
@@ -1,6 +1,6 @@
 #=
 Created on Friday 06 November 2020
-Last update: Tuesday 09 March 2021
+Last update: Monday 22 March 2021
 
 @author: Michiel Stock
 michielfmstock@gmail.com
@@ -15,10 +15,10 @@ function dynamic_time_warping(mo::MaxOperator, θ, D)
 	D[:,1] .= maxintfloat(eltype(D))
 	D[1,:] .= maxintfloat(eltype(D))
 	D[1,1] = 0.0
-	y = zeros(eltype(D), 3)
+	
 	@inbounds for j in 1:m, i in 1:n
-		y .= D[i+1,j], D[i,j], D[i,j+1]
-	 	 D[i+1,j+1] = minimum(mo, y) + θ[i,j]
+		y = (D[i+1,j], D[i,j], D[i,j+1])
+	 	 D[i+1,j+1] = minᵧ(mo, y) + θ[i,j]
 	end
     return D[n+1, m+1]
 end
@@ -42,11 +42,10 @@ function ∂DTW(mo::MaxOperator, θ, D, E, Q)
 	D[:,1] .= maxintfloat(eltype(D))
 	D[1,:] .= maxintfloat(eltype(D))
 	D[1,1] = 0.0
-    y = zeros(eltype(D), 3)
 	@inbounds for j in 1:m, i in 1:n
-		y .= D[i+1,j], D[i,j], D[i,j+1]
+		y = (D[i+1,j], D[i,j], D[i,j+1])
 		# caution, this overwrites y for performance purposes
-		ymin, yargmin = min_argmin(mo, y)
+		ymin, yargmin = min_argminᵧ(mo, y)
     	D[i+1,j+1] = ymin + θ[i,j]
        	Q[i+1,j+1,:] .= yargmin
 	end

--- a/src/maxoperators.jl
+++ b/src/maxoperators.jl
@@ -8,6 +8,8 @@ michielfmstock@gmail.com
 Implementation of the smooth max operators and their gradients.
 =#
 
+# TODO: version that works with tuples
+
 using LinearAlgebra: ⋅, norm
 using StatsBase: mean
 using ChainRulesCore

--- a/src/maxoperators.jl
+++ b/src/maxoperators.jl
@@ -139,10 +139,10 @@ smoothmax_argmax(mo::MaxOperator, x) = frule(smoothmax, mo, x)
 # Minimum
 # -------
 smoothmin(::Max, x) = minimum(x)
-smoothmin(mo::MaxOperator, x) = -smoothmax(mo, -x)
+smoothmin(mo::MaxOperator, x) = -smoothmax(mo, .-x)
 
 function frule(::typeof(smoothmin), mo::MaxOperator, x)
-    m, q = frule(smoothmax, mo, -x)
+    m, q = frule(smoothmax, mo, .-x)
     return -m, q
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,6 +1,6 @@
 #=
 Created on 07/12/2020 09:36:55
-Last update: Friday 5 March 2021
+Last update: Monday 22 March 2021
 
 @author: Michiel Stock
 michielfmstock@gmail.com
@@ -12,7 +12,7 @@ are themselves not the main product.
 
 
 
-# TODO: make this more efficient
+# TODO: make this more efficient, special case for three dims, using a sorting network?
 """
     project_in_simplex(v::Vector, z::Number)
 
@@ -26,6 +26,8 @@ function project_in_simplex(v::Vector{T}, z::Number) where {T<:Number}
     θ = (μcs[ρ] - z) / ρ
     return max.(v .- θ, zero(T))
 end
+
+project_in_simplex(v::Tuple, z::Number) = project_in_simplex([v...], z)
 
 # dot product that only consider finite numbers
 fin_dot(q, x) = sum(qᵢ * xᵢ for (qᵢ, xᵢ) in zip(q, x) if qᵢ > 0 && xᵢ > -Inf)
@@ -55,24 +57,24 @@ exprandg(n::Int) = 1.0 ./ -log.(rand(n))
 
 function _logsumexp(x; γ=1)
     c = maximum(x)
-    return c + γ * log(sum(exp.((x .- c)/γ)))
+    return c + γ * log(sum(exp.((x .- c) ./ γ)))
 end
 
 function logsumexp(X; dims::Union{Nothing,Int}=nothing, γ=1)
     dims isa Nothing && return _logsumexp(X; γ)
     c = maximum(X; dims)
-    return c .+ γ * log.(sum(exp.((X .- c)/γ); dims))
+    return c .+ γ * log.(sum(exp.((X .- c) ./ γ); dims))
 end
 
 function _softmax(x; γ=1)
     m = logsumexp(x; γ)
-    return exp.((x .- m) / γ)
+    return exp.((x .- m) ./ γ)
 end
 
 function softmax(X; dims::Union{Nothing,Int}=nothing, γ=1)
     dims isa Nothing && return _softmax(X; γ)
     m = logsumexp(X; dims, γ)
-    return exp.((X .- m)/γ)
+    return exp.((X .- m) ./ γ)
 end
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -27,7 +27,21 @@ function project_in_simplex(v::Vector{T}, z::Number) where {T<:Number}
     return max.(v .- θ, zero(T))
 end
 
-project_in_simplex(v::Tuple, z::Number) = project_in_simplex([v...], z)
+project_in_simplex(v::Tuple, z) = project_in_simplex([v...], z)
+
+function project_in_simplex((v₁, v₂, v₃)::NTuple{3,T}, z) where {T<:Number}
+    μ₁, μ₂, μ₃ = v₁, v₂, v₃
+    # three comparisions to sort
+    if μ₁ < μ₂; μ₁, μ₂ = μ₂, μ₁; end
+    if μ₂ < μ₃; μ₂, μ₃ = μ₃, μ₂; end
+    if μ₁ < μ₂; μ₁, μ₂ = μ₂, μ₁; end
+    # find theta
+    θ = μ₁ - z
+    μ₂ - 0.5 * (μ₁ + μ₂ - z) > 0.0 && (θ = 0.5 * (μ₁ + μ₂ - z))
+    μ₃ - (1.0 / 3.0) * (μ₁ + μ₂ + μ₃ - z) > 0.0 && (θ = (1.0 / 3.0) * (μ₁ + μ₂ + μ₃ - z))
+    # return vector
+    return max.((v₁, v₂, v₃) .- θ, zero(T))
+end
 
 # dot product that only consider finite numbers
 fin_dot(q, x) = sum(qᵢ * xᵢ for (qᵢ, xᵢ) in zip(q, x) if qᵢ > 0 && xᵢ > -Inf)

--- a/test/maxoperators.jl
+++ b/test/maxoperators.jl
@@ -6,42 +6,42 @@
 
 
         for mo in [Max(), LeakyMax(), EntropyMax(), SquaredMax()]
-            @test maximum(mo, x) isa Number
-            @test maximum(mo, x .+ 1) ≈ maximum(mo, x) + 1
+            @test maxᵧ(mo, x) isa Number
+            @test maxᵧ(mo, x .+ 1) ≈ maxᵧ(mo, x) + 1
 
-            @test maximum(mo, y) isa Number
-            @test maximum(mo, y.+ 1) ≈ maximum(mo, y) + 1
-            @test isfinite(maximum(mo, y))
+            @test maxᵧ(mo, y) isa Number
+            @test maxᵧ(mo, y.+ 1) ≈ maxᵧ(mo, y) + 1
+            @test isfinite(maxᵧ(mo, y))
 
             # max and argmax
-            m, q = max_argmax(mo, x)
+            m, q = max_argmaxᵧ(mo, x)
             @test m isa Number
-            @test m ≈ maximum(mo, x)
+            @test m ≈ maxᵧ(mo, x)
             @test sum(q) ≈ 1.0 && all(q .≥ 0.0)
         end
     end
-#=
+
     @testset "maximum (tuple0" begin 
         x = (1.0, 2.0, 5.0)
         y = (-1.2, 3.3, 5, -maxintfloat(Float64), 0.1)
 
 
         for mo in [Max(), LeakyMax(), EntropyMax(), SquaredMax()]
-            @test maximum(mo, x) isa Number
-            @test maximum(mo, x .+ 1) ≈ maximum(mo, x) + 1
+            @test maxᵧ(mo, x) isa Number
+            @test maxᵧ(mo, x .+ 1) ≈ maxᵧ(mo, x) + 1
 
-            @test maximum(mo, y) isa Number
-            @test maximum(mo, y.+ 1) ≈ maximum(mo, y) + 1
-            @test isfinite(maximum(mo, y))
+            @test maxᵧ(mo, y) isa Number
+            @test maxᵧ(mo, y.+ 1) ≈ maxᵧ(mo, y) + 1
+            @test isfinite(maxᵧ(mo, y))
 
             # max and argmax
-            m, q = max_argmax(mo, x)
+            m, q = max_argmaxᵧ(mo, x)
             @test m isa Number
-            @test m ≈ maximum(mo, x)
+            @test m ≈ maxᵧ(mo, x)
             @test sum(q) ≈ 1.0 && all(q .≥ 0.0)
         end
     end
-=#
+
 
     @testset "minimum" begin 
     x = -[1.0, 2.0, 5.0]
@@ -49,17 +49,17 @@
 
 
     for mo in [Max(), LeakyMax(), EntropyMax(), SquaredMax()]
-        @test minimum(mo, x) isa Number
-        @test minimum(mo, x .+ 1) ≈ minimum(mo, x) + 1
+        @test minᵧ(mo, x) isa Number
+        @test minᵧ(mo, x .+ 1) ≈ minᵧ(mo, x) + 1
 
-        @test minimum(mo, y) isa Number
-        @test minimum(mo, y.+ 1) ≈ minimum(mo, y) + 1
-        @test isfinite(minimum(mo, y))
+        @test minᵧ(mo, y) isa Number
+        @test minᵧ(mo, y.+ 1) ≈ minᵧ(mo, y) + 1
+        @test isfinite(minᵧ(mo, y))
 
         # max and argmax
-        m, q = min_argmin(mo, x)
+        m, q = min_argminᵧ(mo, x)
         @test m isa Number
-        @test m ≈ minimum(mo, x)
+        @test m ≈ minᵧ(mo, x)
         @test sum(q) ≈ 1.0 && all(q .≥ 0.0)
     end
 end

--- a/test/maxoperators.jl
+++ b/test/maxoperators.jl
@@ -20,6 +20,28 @@
             @test sum(q) ≈ 1.0 && all(q .≥ 0.0)
         end
     end
+#=
+    @testset "maximum (tuple0" begin 
+        x = (1.0, 2.0, 5.0)
+        y = (-1.2, 3.3, 5, -maxintfloat(Float64), 0.1)
+
+
+        for mo in [Max(), LeakyMax(), EntropyMax(), SquaredMax()]
+            @test maximum(mo, x) isa Number
+            @test maximum(mo, x .+ 1) ≈ maximum(mo, x) + 1
+
+            @test maximum(mo, y) isa Number
+            @test maximum(mo, y.+ 1) ≈ maximum(mo, y) + 1
+            @test isfinite(maximum(mo, y))
+
+            # max and argmax
+            m, q = max_argmax(mo, x)
+            @test m isa Number
+            @test m ≈ maximum(mo, x)
+            @test sum(q) ≈ 1.0 && all(q .≥ 0.0)
+        end
+    end
+=#
 
     @testset "minimum" begin 
     x = -[1.0, 2.0, 5.0]

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -15,6 +15,10 @@
         q = project_in_simplex([1.0, 2.0, 3.0], 1.0)
         @test sum(q) ≈ 1 && all(0 .≤ q .≤ 1)
         @test q ≈ project_in_simplex([1.0, 2.0, 3.0] .+1, 1.0)
+
+        q = project_in_simplex((1.0, 2.0, 3.0), 1.0)
+        @test sum(q) ≈ 1 && all(0 .≤ q .≤ 1)
+        @test all(q .≈ project_in_simplex((1.0, 2.0, 3.0) .+1, 1.0))
     end
 
     @testset "softmax etc" begin


### PR DESCRIPTION
- switched to a different notation: `smoothmax` and `smoothmin`
- shortcut `maxᵧ` and `minᵧ` to look more like the equations
- maximum is now computed using tuples rather than arrays, resulting in a major performance increase ⚡
- similarly, I use a sorting network to compute the squared-max on three tuples, this is now blazingly fast ⚡⚡
